### PR TITLE
ENH: Add modules for workspace configuration

### DIFF
--- a/modules/10-python-venv
+++ b/modules/10-python-venv
@@ -1,0 +1,21 @@
+# The following variables can be defined in a
+# `.workspace.config` file for python-venv workspace:
+
+# * `workspace_virtual_env`: This variable defines the Python virtual
+# environment that is automatically loaded when working in
+# the current workspace.
+
+# This variable should be defined as `local` variables to avoid
+# polluting the environment.
+
+function python-venv_activate_workspace {
+    if [[ -n "$workspace_virtual_env" ]]; then
+        workon $workspace_virtual_env
+    fi
+}
+
+function python-venv_deactivate_workspace {
+    if [[ -n "$workspace_virtual_env" ]]; then
+        deactivate
+    fi
+}

--- a/modules/10-spack
+++ b/modules/10-spack
@@ -1,0 +1,25 @@
+# The following variables can be defined in a
+# `.workspace.config` file for spack workspace:
+
+# * `workspace_spack_packages`: This variable defines the list of
+# spack packages that are automatically loaded when working in
+# the current workspace.
+
+# This variable should be defined as `local` variables to avoid
+# polluting the environment.
+
+function spack_deactivate_workspace {
+        if [[ -n "$workspace_spack_packages" ]]; then
+            for package in ${workspace_spack_packages[@]}; do
+                spack unload $package
+            done
+        fi
+}
+
+function spack_activate_workspace {
+    if [[ -n "$workspace_spack_packages" ]]; then
+        for package in ${workspace_spack_packages[@]}; do
+            spack load $package
+        done
+    fi
+}

--- a/workspace.config
+++ b/workspace.config
@@ -3,25 +3,15 @@
 # The configuration is defined in a file called .workspace.config
 # that is contained in any folder. If such a file is found
 # in the current folder or any of its parents, this file
-# is sourced. The following variables can be defined in a
-#`.workspace.config` file:
+# is sourced.
 
-# * `workspace_virtual_env`: This variable defines the Python virtual
-# environment that is automatically loaded when working in
-# the current workspace.
-# * `workspace_spack_packages`: This variable defines the list of
-# spack packages that are automatically loaded when working in
-# the current workspace.
+# Functions defined in module files contained in the subdirectory
+# called "modules" are used to activate and deactivate the current
+# workspace.
 
-# These variables should be defined as `local` variables to avoid
-# polluting the environment.
-
-# These variables are convenient as they are understood by the
-# functions defined in this file, and will automatically
-# load the correct modules when entering in the workspace,
-# unload the modules when leaving the workspace, activate the
-# current virtual environment when entering in the workspace,
-# and deactivating the virtual environment when leaving the workspace.
+# `${module}_activate_workspace and `${module}_deactivate_workspace`
+# can be defined to run actions that are executed when a workspace
+# is activated (entering) or deactivated (leaving).
 
 # Limitation:
 # There is currently no clean way to detect if `.workspace.config` is called
@@ -52,14 +42,10 @@ function _function_lock {
 function _deactivate_workspace {
     if [[ -f "$CURRENT_WORKSPACE/$config_filename" ]]; then
         source "$CURRENT_WORKSPACE/$config_filename"
-        if [[ -n "$workspace_virtual_env" ]]; then
-            deactivate
-        fi
-        if [[ -n "$workspace_spack_packages" ]]; then
-            for package in ${workspace_spack_packages[@]}; do
-                spack unload $package
-            done
-        fi
+        for func in $list_deactivate_functions
+        do
+            $func
+        done
     fi
     unset CURRENT_WORKSPACE
 }
@@ -75,14 +61,10 @@ function deactivate_workspace {
 function _activate_workspace {
     source "$current_path/$config_filename"
     export CURRENT_WORKSPACE=$current_path
-    if [[ -n "$workspace_virtual_env" ]]; then
-        workon $workspace_virtual_env
-    fi
-    if [[ -n "$workspace_spack_packages" ]]; then
-        for package in ${workspace_spack_packages[@]}; do
-            spack load $package
-        done
-    fi
+    for func in $list_activate_functions
+    do
+        $func
+    done
 }
 
 # Manually activate a workspace
@@ -126,6 +108,40 @@ function chpwd {
     _function_lock _deactivate_workspace
     unset WORKSPACE_CONFIG_LOOK_UP
 }
+
+function _add_function_to_list {
+  # Check if functions exist and add them to list of available functions
+  function_name=$1$2
+  $(type -f $function_name)
+  if [[ $? == 0 ]]; then
+    echo $function_name
+    return
+  fi
+}
+
+# Get this script directory
+if [ -n "$ZSH_VERSION" ]; then
+   # assume Zsh
+    DIR="$(dirname ${(%):-%N})"
+else
+   # assume Bash
+   # Do not check "$BASH_VERSION"
+   DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+fi
+
+#Expected functions
+local activate_function_suffix="_activate_workspace"
+local deactivate_function_suffix="_deactivate_workspace"
+# Load all modules
+
+for name in $(find $DIR/modules/*);
+do
+  # Get module name
+  source $name
+  module=$(echo $name | sed -n 's;[^-]*-\(.*\);\1;p')
+  list_activate_functions+=($(_add_function_to_list $module $activate_function_suffix))
+  list_deactivate_functions+=($(_add_function_to_list $module $deactivate_function_suffix))
+done
 
 # Force call chpwd when sourcing this file.
 chpwd


### PR DESCRIPTION
Instead of hardcoding actions that are executed when entering and leaving
the workspace, the actions are defined in modules files. Each module can
define a function that is run when entering in the workspace
`${module}_activate_workspace` and a function that is run when leaving the workspace
`${module}_deactivate_workspace.

New modules can be added to extend the functionalities of this framework.