### PR TITLE
Corrects various problems with bash

### DIFF
--- a/workspace.config
+++ b/workspace.config
@@ -33,7 +33,7 @@ function _function_lock {
 function _deactivate_workspace {
     if [[ -f "$CURRENT_WORKSPACE/$config_filename" ]]; then
         source "$CURRENT_WORKSPACE/$config_filename"
-        for func in $list_deactivate_functions
+        for func in ${list_deactivate_functions[@]}
         do
             $func
         done
@@ -52,7 +52,7 @@ function deactivate_workspace {
 function _activate_workspace {
     source "$current_path/$config_filename"
     export CURRENT_WORKSPACE=$current_path
-    for func in $list_activate_functions
+    for func in ${list_activate_functions[@]}
     do
         $func
     done
@@ -120,6 +120,14 @@ function chpwd {
     unset WORKSPACE_CONFIG_LOOK_UP
 }
 
+# Zsh has `chpwd` hook, but Bash does not have it builtin.
+# Both shells have the function `cd` builtin.
+function cd {
+  builtin cd "$1"
+  chpwd
+}
+
+
 function _add_function_to_list {
   # Check if functions exist and add them to list of available functions
   function_name=$1$2
@@ -139,6 +147,10 @@ else
    # Do not check "$BASH_VERSION"
    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 fi
+
+#Reset array variables
+unset list_activate_functions
+unset list_deactivate_functions
 
 #Expected functions
 activate_function_suffix="_activate_workspace"


### PR DESCRIPTION
* Bash does not have the hook `chpwd` builtin. We need to overload the
`cd` function and add a call to `chpwd`.
* Reset array variables when `workspace.config` is sourced. This allows
to source the file again after modifying it.
* Explicitly use array variables as arrays in `for` loops